### PR TITLE
/data API で 500 エラーが出ていた問題の修正

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -191,7 +191,7 @@ SQL
                 raise "unknown method #{method}"
               end
     res = fetcher.call(uri, params, headers)
-    JSON.parse(res.body)
+    JSON.parse(res)
   end
 
   get '/data' do


### PR DESCRIPTION
Ruby にそんなに詳しくないので、レビューいただけたら幸いです。直した問題は下記の3つです。
## 1. /data API で TypeError - can't dup NilClass

ログイン後にしばらく放置していると、定期的に下記のような 500 エラーが出ていた。`nil` に対して `dup()` メソッドを実行しているのが原因？

```
2015-10-18 22:52:06 - TypeError - can't dup NilClass:
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:212:in `dup'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:212:in `block (2 levels) in <class:WebApp>'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:208:in `each_pair'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:208:in `block in <class:WebApp>'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610:in `block in compile!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `[]'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `block (3 levels) in route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:993:in `route_eval'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `block (2 levels) in route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1014:in `block in process_route'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1012:in `catch'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1012:in `process_route'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:972:in `block in route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:971:in `each'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:971:in `route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1084:in `block in dispatch!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `block in invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `catch'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1081:in `dispatch!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:906:in `block in call!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `block in invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `catch'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:906:in `call!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:894:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:225:in `context'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:220:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/xss_header.rb:18:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/path_traversal.rb:16:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/json_csrf.rb:18:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/frame_options.rb:31:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/nulllogger.rb:9:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/head.rb:13:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/show_exceptions.rb:21:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:181:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:2021:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1486:in `block in call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1795:in `synchronize'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1486:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/tempfile_reaper.rb:15:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/lint.rb:49:in `_call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/lint.rb:37:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/showexceptions.rb:24:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/commonlogger.rb:33:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:218:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/chunked.rb:54:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/content_length.rb:15:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/handler/webrick.rb:88:in `service'
        /usr/lib/ruby/2.1.0/webrick/httpserver.rb:138:in `service'
        /usr/lib/ruby/2.1.0/webrick/httpserver.rb:94:in `run'
        /usr/lib/ruby/2.1.0/webrick/server.rb:295:in `block in start_thread'

```
## 2. 上記を直したら `URI::InvalidURIError - bad URI(is not URI?): http://127.0.0.1:8080/["6900014"]`

上記を直したら、以下のようなエラー。配列が引数に展開されていないっぽい。

2015-10-18 22:55:35 - URI::InvalidURIError - bad URI(is not URI?): http://127.0.0.1:8080/["6900014"]:
        /usr/lib/ruby/2.1.0/uri/common.rb:176:in `split'
        /usr/lib/ruby/2.1.0/uri/common.rb:211:in`parse'
        /usr/lib/ruby/2.1.0/uri/common.rb:747:in `parse'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/httpclient-2.6.0.1/lib/httpclient/util.rb:134:in`urify'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/httpclient-2.6.0.1/lib/httpclient.rb:1268:in `to_resource_url'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/httpclient-2.6.0.1/lib/httpclient.rb:1039:in`follow_redirect'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/httpclient-2.6.0.1/lib/httpclient.rb:625:in `get_content'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:194:in`call'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:194:in `fetch_api'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:218:in`block (2 levels) in class:WebApp'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:208:in `each_pair'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:208:in`block in class:WebApp'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610:in`block in compile!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `[]'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in`block (3 levels) in route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:993:in `route_eval'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in`block (2 levels) in route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1014:in `block in process_route'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1012:in`catch'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1012:in `process_route'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:972:in`block in route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:971:in `each'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:971:in`route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1084:in `block in dispatch!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in`block in invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `catch'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in`invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1081:in `dispatch!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:906:in`block in call!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `block in invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in`catch'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:906:in`call!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:894:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:225:in`context'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:220:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/xss_header.rb:18:in`call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/path_traversal.rb:16:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/json_csrf.rb:18:in`call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in`call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/frame_options.rb:31:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/nulllogger.rb:9:in`call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/head.rb:13:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/show_exceptions.rb:21:in`call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:181:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:2021:in`call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1486:in `block in call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1795:in`synchronize'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1486:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/tempfile_reaper.rb:15:in`call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/lint.rb:49:in `_call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/lint.rb:37:in`call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/showexceptions.rb:24:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/commonlogger.rb:33:in`call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:218:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/chunked.rb:54:in`call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/content_length.rb:15:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/handler/webrick.rb:88:in`service'
        /usr/lib/ruby/2.1.0/webrick/httpserver.rb:138:in `service'
        /usr/lib/ruby/2.1.0/webrick/httpserver.rb:94:in`run'
        /usr/lib/ruby/2.1.0/webrick/server.rb:295:in `block in start_thread'
## 3. さらに直したら `NoMethodError - undefined method`body' for #String:0x007f033c7710f0`

さらに直すと以下のエラー。`get_content` は戻り値が `String` 型っぽい。

```
2015-10-18 23:04:45 - NoMethodError - undefined method `body' for #<String:0x007f033c7710f0>:
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:195:in `fetch_api'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:218:in `block (2 levels) in <class:WebApp>'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:208:in `each_pair'
        /home/hiroshi/git/github.com/tagomoris/isucon5-final/webapp/ruby/app.rb:208:in `block in <class:WebApp>'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610:in `block in compile!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `[]'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `block (3 levels) in route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:993:in `route_eval'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `block (2 levels) in route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1014:in `block in process_route'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1012:in `catch'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1012:in `process_route'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:972:in `block in route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:971:in `each'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:971:in `route!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1084:in `block in dispatch!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `block in invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `catch'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1081:in `dispatch!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:906:in `block in call!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `block in invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `catch'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `invoke'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:906:in `call!'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:894:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:225:in `context'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:220:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/xss_header.rb:18:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/path_traversal.rb:16:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/json_csrf.rb:18:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-protection-1.5.3/lib/rack/protection/frame_options.rb:31:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/nulllogger.rb:9:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/head.rb:13:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/show_exceptions.rb:21:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:181:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:2021:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1486:in `block in call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1795:in `synchronize'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1486:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/tempfile_reaper.rb:15:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/lint.rb:49:in `_call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/lint.rb:37:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/showexceptions.rb:24:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/commonlogger.rb:33:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:218:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/chunked.rb:54:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/content_length.rb:15:in `call'
        /home/hiroshi/.rvm/gems/ruby-2.2.1/gems/rack-1.6.4/lib/rack/handler/webrick.rb:88:in `service'
        /usr/lib/ruby/2.1.0/webrick/httpserver.rb:138:in `service'
        /usr/lib/ruby/2.1.0/webrick/httpserver.rb:94:in `run'
        /usr/lib/ruby/2.1.0/webrick/server.rb:295:in `block in start_thread'
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tagomoris/isucon5-final/9)

<!-- Reviewable:end -->
